### PR TITLE
Add handling for full draft pool.

### DIFF
--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -1,16 +1,25 @@
 use serenity::builder::CreateEmbed;
-use serenity::model::channel::{ Embed };
-use ::models::draft_pool::*;
+use serenity::model::channel::{ Embed, Message };
+use ::models::game::Game;
 use ::traits::has_members::HasMembers;
 
 command!(add(ctx, msg, _args) {
+  fn consume_message(msg: &Message, embed: Embed) {
+    match msg.channel_id.send_message(|m| m.embed(|_| CreateEmbed::from(embed))) {
+      Ok(_) => (),
+      Err(what) => panic!(what)
+    }
+  }
+
   let mut data = ctx.data.lock();
-  let mut draft_pool = data.get_mut::<DraftPool>().unwrap();
-  let author = msg.author.clone();
-  let embed: Embed = draft_pool.add_member(author);
-  let message = msg.channel_id.send_message(|m| m.embed(|_| CreateEmbed::from(embed)));
-  match message {
-    Ok(_) => (),
-    Err(what) => panic!(what),
+  let game = data.get_mut::<Game>().unwrap();
+
+  if !game.draft_pool.is_open() {
+    let embed: Embed = game.draft_pool.members_full_embed(165, 255, 241);
+    consume_message(msg, embed);
+  } else {
+    let author = msg.author.clone();
+    let embed: Embed = game.draft_pool.add_member(author);
+    consume_message(msg, embed);
   }
 });

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,8 +20,6 @@ use serenity::http;
 use std::collections::HashSet;
 use std::env;
 
-use models::team::Team;
-
 struct Handler;
 
 impl EventHandler for Handler {
@@ -87,12 +85,8 @@ fn main() {
   };
   {
     let mut data = client.data.lock();
-    let teams: Vec<models::team::Team> = vec![1, 2]
-      .into_iter()
-      .map(|i| models::team::Team { id: i, captain: None, members: Vec::new() })
-      .collect();
     let draft_pool = models::draft_pool::DraftPool { members: Vec::new() };
-    let game = models::game::Game { teams: teams, draft_pool: draft_pool };
+    let game = models::game::Game { teams: None, draft_pool: draft_pool };
     data.insert::<models::game::Game>(game);
   }
 

--- a/src/models/game.rs
+++ b/src/models/game.rs
@@ -3,7 +3,7 @@ use ::models::draft_pool::DraftPool;
 use typemap::Key;
 
 pub struct Game {
-  pub teams: Vec<Team>,
+  pub teams: Option<Vec<Team>>,
   pub draft_pool: DraftPool
 }
 

--- a/src/models/team.rs
+++ b/src/models/team.rs
@@ -42,16 +42,16 @@ impl HasMembers for Team {
   fn add_member(&mut self, user: User) -> Embed {
     self.members.push(user);
     self.members.dedup();
-    self.create_embed(255, 223, 165)
+    self.members_changed_embed(255, 223, 165)
   }
 
   fn remove_member(&mut self, user: User) -> Embed {
     self.members.retain(|m| m.id != user.id);
     self.members.dedup();
-    self.create_embed(255, 223, 165)
+    self.members_changed_embed(255, 223, 165)
   }
 
-  fn create_embed(&mut self, r: u8, g: u8, b: u8) -> Embed {
+  fn members_changed_embed(&mut self, r: u8, g: u8, b: u8) -> Embed {
     let members = &self.members;
 
     Embed {

--- a/src/traits/has_members.rs
+++ b/src/traits/has_members.rs
@@ -4,5 +4,5 @@ use serenity::model::user::User;
 pub trait HasMembers {
   fn add_member(&mut self, user: User) -> Embed;
   fn remove_member(&mut self, user: User) -> Embed;
-  fn create_embed(&mut self, r: u8, g: u8, b: u8) -> Embed;
+  fn members_changed_embed(&mut self, r: u8, g: u8, b: u8) -> Embed;
 }


### PR DESCRIPTION
When the draft pool is full, don't let anyone else `~add` themselves.

Once the pool fills up, send a message to the channel to let people know captains will be picked next.