### PR TITLE
Extract struct functionality out to traits

### DIFF
--- a/src/pugbot/models/draft_pool.rs
+++ b/src/pugbot/models/draft_pool.rs
@@ -1,6 +1,7 @@
 use serenity::model::channel::{ Embed, EmbedFooter };
 use serenity::model::user::User;
 use serenity::utils::Colour;
+use ::traits::pool_availability::*;
 use typemap::Key;
 
 use queue_size;
@@ -10,12 +11,12 @@ pub struct DraftPool {
   pub members: Vec<User>,
 }
 
-impl DraftPool {
-  pub fn is_open(&self) -> bool {
-    (self.members.len() as u32) < queue_size()
+impl PoolAvailability for DraftPool {
+  fn is_open(&self) -> bool {
+    (self.members().len() as u32) < queue_size()
   }
 
-  pub fn members_full_embed(&mut self, r: u8, g: u8, b: u8) -> Embed {
+  fn members_full_embed(&mut self, r: u8, g: u8, b: u8) -> Embed {
     let members = self.members.clone();
 
     Embed {
@@ -41,6 +42,10 @@ impl DraftPool {
 }
 
 impl HasMembers for DraftPool {
+  fn members(&self) -> Vec<User> {
+    self.members
+  }
+
   fn add_member(&mut self, user: User) -> Embed {
     self.members.push(user);
     self.members.dedup();

--- a/src/pugbot/models/game.rs
+++ b/src/pugbot/models/game.rs
@@ -1,5 +1,5 @@
 use ::models::team::Team;
-use ::models::draft_pool::DraftPool;
+use ::traits::pool_availability::PoolAvailability;
 use typemap::Key;
 
 pub struct Game {

--- a/src/pugbot/models/team.rs
+++ b/src/pugbot/models/team.rs
@@ -39,6 +39,8 @@ impl Key for Team {
 }
 
 impl HasMembers for Team {
+  fn members(&self) -> Vec<User> { self.members }
+
   fn add_member(&mut self, user: User) -> Embed {
     self.members.push(user);
     self.members.dedup();

--- a/src/pugbot/traits/has_members.rs
+++ b/src/pugbot/traits/has_members.rs
@@ -2,6 +2,7 @@ use serenity::model::channel::{ Embed };
 use serenity::model::user::User;
 
 pub trait HasMembers {
+  fn members(&self) -> Vec<User>;
   fn add_member(&mut self, user: User) -> Embed;
   fn remove_member(&mut self, user: User) -> Embed;
   fn members_changed_embed(&mut self, r: u8, g: u8, b: u8) -> Embed;

--- a/src/pugbot/traits/mod.rs
+++ b/src/pugbot/traits/mod.rs
@@ -1,1 +1,2 @@
+pub mod pool_availability;
 pub mod has_members;

--- a/src/pugbot/traits/pool_availability.rs
+++ b/src/pugbot/traits/pool_availability.rs
@@ -1,0 +1,7 @@
+use traits::has_members::HasMembers;
+use serenity::model::channel::Embed;
+
+pub trait PoolAvailability: HasMembers {
+  fn is_open(&self) -> bool;
+  fn members_full_embed(&mut self, r: u8, g: u8, b: u8) -> Embed;
+}


### PR DESCRIPTION
This adds the `PoolAvailability` trait, as well as expands the `HasMembers` trait. The hope I have is by putting functionality in traits, I can leverage polymorphism to create better tests when needed.